### PR TITLE
VIQE dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,14 @@ one to plot the data. The dashboard fetches new data from Quantum
 Leap every few seconds, so as the simulator sends entities you should
 be able to see the new data points reflected in the plot.
 
-Likewise, if you browse to the VIQE dashboard at:
+Likewise, if you browse to the Sleuth dashboard at:
 
-- http://localhost:8000/dazzler/demo/-/viqe
+- http://localhost:8000/dazzler/demo/-/sleuth
 
-You should be able to monitor in real-time the VIQE inspection reports
-as the simulator produces them.
+You should be able to monitor in real-time inspection reports as the
+simulator produces them. (Sleuth is a made-up AI service that inspects
+parts being machined to sniff out surface areas where defects are likely
+to be. Loosely based on the first implementation of VIQE.)
 
 
 

--- a/dazzler/__init__.py
+++ b/dazzler/__init__.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 
 
 def pyproject_file() -> Path:

--- a/dazzler/config.py
+++ b/dazzler/config.py
@@ -21,8 +21,12 @@ class BoardAssembly(BaseModel):
     board_path: Optional[str]
 
 
-BOOTSTRAP_DEMO_BOARD = BoardAssembly(
-            builder='dazzler.dash.board.dbc_demo.dash_builder')
+def demo_boards() -> List[BoardAssembly]:
+    bootstrap_demo_board = BoardAssembly(
+        builder='dazzler.dash.board.dbc_demo.dash_builder')
+    return [bootstrap_demo_board]
+
+
 DEMO_TENANT_NAME = 'demo'
 
 CONFIG_FILE_ENV_VAR_NAME = 'DAZZLER_CONFIG'
@@ -30,9 +34,15 @@ CONFIG_FILE_ENV_VAR_NAME = 'DAZZLER_CONFIG'
 
 class Settings(BaseSettings):
     quantumleap_base_url: AnyHttpUrl = 'http://quantumleap:8668'
-    boards: Dict[TenantName, List[BoardAssembly]] = {
-        DEMO_TENANT_NAME: [BOOTSTRAP_DEMO_BOARD]
-    }
+    boards: Dict[TenantName, List[BoardAssembly]] = {}
+
+    @staticmethod
+    def demo_config() -> 'Settings':
+        cfg = Settings()
+        cfg.boards = {
+            DEMO_TENANT_NAME: demo_boards()
+        }
+        return cfg
 
     @staticmethod
     def load() -> 'Settings':
@@ -41,7 +51,8 @@ class Settings(BaseSettings):
             env_var_name=CONFIG_FILE_ENV_VAR_NAME, defaults={})
         if raw_settings:
             return Settings(**raw_settings)
-        return Settings()
+
+        return Settings.demo_config()
 
 
 def dazzler_config() -> Settings:

--- a/dazzler/dash/board/inspection_demo.py
+++ b/dazzler/dash/board/inspection_demo.py
@@ -5,51 +5,51 @@ import pandas as pd
 import plotly.express as px
 
 from dazzler.dash.entitymon import EntityMonitorDashboard
-from dazzler.ngsy import RAW_MATERIAL_INSPECTION_TYPE
+from dazzler.ngsy import INSPECTION_DEMO_TYPE
 
 
 def dash_builder(app: Dash) -> Dash:
-    return ViqeDashboard(app).build_dash_app()
+    return InspectionDemoDashboard(app).build_dash_app()
 
 
-class ViqeDashboard(EntityMonitorDashboard):
+class InspectionDemoDashboard(EntityMonitorDashboard):
 
     def __init__(self, app: Dash):
         super().__init__(
             app=app,
             title='Defect Size',
-            entity_type=RAW_MATERIAL_INSPECTION_TYPE
+            entity_type=INSPECTION_DEMO_TYPE
         )
 
     def empty_data_set(self) -> dict:
         return {
             'index': [0],
-            'Area': [0],
-            'Inspection_Result': [False]
+            'area': [0],
+            'okay': [False]
         }
 
     def explanation(self) -> str:
         return \
         '''
-        This graph visualises VIQE inspection reports as they come in.
+        This graph visualises inspection reports as they come in.
         Each report is for a part being machined and is made up by a
         sequence of part surface areas where defects are likely to be.
-        There's a bubble on the graph for each surface area where VIQE
+        There's a bubble on the graph for each surface area where the AI
         thinks there could be a defect, each bubble size is proportional
         to the corresponding real-world size of the area inspected on the
         part and orange bubbles indicate highly likely defects.
 
         The graph updates automatically every few seconds so you can monitor
         your machining process in near real time. To start a monitoring
-        session, load the IDs of the available VIQE reports, then pick the
+        session, load the IDs of the available reports, then pick the
         one you're interested in. Optionally choose how many data points
         back in time to display from the latest received data point.
         '''
 
     def make_figure(self, df: pd.DataFrame) -> Any:
         color_map = {True: 'coral', False: 'silver'}
-        fig = px.scatter(df, x=df.index, y=df.Area, size=df.Area,
-                            color='Inspection_Result',
+        fig = px.scatter(df, x=df.index, y=df.area, size=df.area,
+                            color='okay',
                             color_discrete_map=color_map)
         fig.update_layout(legend_title_text='Defect?')
         return fig

--- a/dazzler/dash/board/viqe.py
+++ b/dazzler/dash/board/viqe.py
@@ -1,0 +1,121 @@
+from typing import Any, Dict
+
+from dash import Dash
+import pandas as pd
+import plotly.express as px
+from pydantic import BaseModel
+
+from dazzler.dash.entitiesframe import EntitiesFrameDashboard
+from dazzler.ngsy import RAW_MATERIAL_INSPECTION_TYPE
+
+
+class InspectionReport(BaseModel):
+    """Holds the data to visualise a VIQE inspection report.
+    There's two types of VIQE reports, raw materials and tweezers, and an
+    NGSI entity type for each one. But this class collapses the two types
+    into one, more convenient representation for plotting data.
+    """
+    id: str
+    conformance: float
+    scrap: bool
+    spec: str
+
+    @staticmethod
+    def empty() -> 'InspectionReport':
+        return InspectionReport(
+            id='', conformance=0, scrap=False, spec=''
+        )
+
+
+class ReportFrame:
+    """Converts the entity type series dictionary retrieved from Quantum
+    Leap to a Pandas data frame we can plot.
+    """
+
+    def __init__(self, entity_type_series: Dict[str, pd.DataFrame]):
+        self._frames = entity_type_series
+
+    @staticmethod
+    def _most_recent_row(entity_series: pd.DataFrame) -> pd.Series:
+        max_cols = entity_series.idxmax()
+        max_time_index = max_cols['index']
+        return entity_series.iloc[max_time_index]
+
+# NOTE. Paranoia. There should always be exactly one inspection for each
+# entity ID since the inspection is a one-off kind of thing done on one
+# item and item ID == entity ID. But we do this just in case sometime
+# down the line someone decided to have multiple reports for one item,
+# e.g. think doing an inspection on the same item again b/c instruments
+# were out of whack during the first inspection.
+
+    @staticmethod
+    def _from_entity_series(entity_id: str, frame: pd.DataFrame) \
+                            -> InspectionReport:
+        report = InspectionReport.empty()
+        report.id = entity_id
+
+        payload = ReportFrame._most_recent_row(frame)
+        report.conformance = payload.get('conformance_indicator', 1)
+        report.scrap = not payload.get('okay', False)
+        report.spec = payload.get('spec', '')
+
+        return report
+
+    def build(self) -> pd.DataFrame:
+        rows = [self._from_entity_series(entity_id, frame).dict()
+                for (entity_id, frame) in self._frames.items()]
+        return pd.DataFrame(rows)
+
+
+
+def raw_material_dash_builder(app: Dash) -> Dash:
+    return RawMaterialInspectionDashboard(app).build_dash_app()
+
+
+class RawMaterialInspectionDashboard(EntitiesFrameDashboard):
+
+    def __init__(self, app: Dash):
+        super().__init__(
+            app=app,
+            title='Raw Materials Inspection',
+            entity_type=RAW_MATERIAL_INSPECTION_TYPE
+        )
+
+    def empty_data_frame(self) -> pd.DataFrame:
+        rows = [InspectionReport.empty().dict()]
+        return pd.DataFrame(rows)
+
+    def entity_type_series_to_data_frame(self,
+                                         frames: Dict[str, pd.DataFrame]) \
+                                        -> pd.DataFrame:
+        if frames:
+            return ReportFrame(frames).build()
+        return self.empty_data_frame()  # no data, draw empty plot
+
+    def make_figure(self, frames: Dict[str, pd.DataFrame]) -> Any:
+        df = self.entity_type_series_to_data_frame(frames)
+        color_map = {True: 'coral', False: 'silver'}
+        fig = px.bar(df, x=df.id, y=df.conformance,
+                        color='scrap',
+                        color_discrete_map=color_map)
+        fig.update_layout(legend_title_text='Scrap?')
+        return fig
+
+    def explanation(self) -> str:
+        return \
+        '''
+        This graph visualises raw material inspections VIQE did in the
+        selected time interval.
+        Each inspection refers to a specific raw material item which is
+        identified by an ID label. There's a bar on the graph for each
+        ID. The bar indicates the degree to which the inspected item conforms
+        to the spec. Zero means no significant deviations from the spec,
+        one means the item is probably to be scrapped. The spec determines
+        a conformance threshold `t` in `(0, 1)` so items with a value less
+        or equal to `t` conform to the spec whereas values greater than
+        `t` do not. Accordingly, a grey bar means "below or equal to the
+        threshold", whereas orange means "above the threshold".
+
+        To plot inspections, select a time interval and then click on
+        the "Load Entities" button.
+        '''

--- a/dazzler/dash/components.py
+++ b/dazzler/dash/components.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from typing import Optional
+
+import dash
+import dash_bootstrap_components as dbc
+
+
+def event_source_id() -> str:
+    """Extract the ID of the UI component that triggered the current
+    event. This function should only be called inside a Dash callback
+    handler.
+
+    Returns:
+        The (string) ID of the component or the empty string if the
+        component couldn't be determined.
+    """
+    try:
+        prop_id = dash.callback_context.triggered[0]['prop_id']
+    except (IndexError, KeyError):
+        prop_id = ''
+    return prop_id.split('.')[0]
+
+    # NOTE. No, apparently in Dash 2.3 (the one we've got) there isn't
+    # a better way of doing this. In fact, the docs suggest to use this
+    # horrendous one liner
+    #
+    #   dash.callback_context.triggered[0]['prop_id'].split('.')[0]
+    #
+    # But Dash 2.4 sort of fixed the horror, so you can just query
+    # `ctx.triggered_id`.
+    # See:
+    # - https://dash.plotly.com/determining-which-callback-input-changed
+
+    # TODO. Replace above code w/ `ctx.triggered_id` when upgrading to
+    # Dash 2.4.
+
+
+def has_triggered(component_id: str) -> bool:
+    """Has the given component triggered the current UI callback?
+    This function should only be called inside a Dash callback handler.
+
+    Args:
+        component_id: the ID of the component to test.
+
+    Returns:
+        `True` for yes, `False` for no.
+    """
+    return event_source_id() == component_id
+
+
+def datetime_local_input(component_id: str) -> dbc.Input:
+    """Build a date-time picker component.
+
+    Args:
+        component_id: the ID to assign to the component.
+
+    Returns:
+        An Dash Bootstrap `Input` component with a type of `datetime-local`.
+    """
+    return dbc.Input(id=component_id, type='datetime-local')
+
+    # NOTE. 'datetime-local' type. It's part of HTML 5 and works in most
+    # recent browsers. It looks like it's a better option than Dash's own
+    # picker which only lets you pick a day but not a time of the day.
+    # See:
+    # - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local
+    # - https://caniuse.com/?search=datetime-local
+
+
+def from_datetime_local_input(value: Optional[str]) -> Optional[datetime]:
+    """Parse the value of a datetime local input field.
+
+    Args:
+        value: the field's value.
+
+    Returns:
+        The parsed `datetime` object if the input string is valid, `None`
+        otherwise.
+    """
+    try:
+        return datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return None

--- a/dazzler/dash/entitiesframe.py
+++ b/dazzler/dash/entitiesframe.py
@@ -1,0 +1,129 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+from dash import Dash, Input, Output, dcc, html
+from dash.development.base_component import Component
+import dash_bootstrap_components as dbc
+import pandas as pd
+
+from dazzler.dash.components import has_triggered, datetime_local_input, \
+    from_datetime_local_input
+from dazzler.dash.wiring import BasePath
+from dazzler.dash.timeseries import QuantumLeapSource
+
+
+LOAD_BUTTON_ID = 'load-button'
+ENTRIES_FROM_INPUT_ID = 'entries-from'
+ENTRIES_TO_INPUT_ID = 'entries-to'
+GRAPH_ID = 'graph'
+
+
+class EntitiesFrameDashboard(ABC):
+
+    def __init__(self, app: Dash,
+                    title: str, entity_type: str):
+        super().__init__()
+        self._app = app
+        self._title = title
+        self._entity_type = entity_type
+        self._base_path = BasePath.from_board_app(app)
+        self._quantumleap = QuantumLeapSource(app)
+
+    @abstractmethod
+    def explanation(self) -> str:
+        pass
+
+    @abstractmethod
+    def make_figure(self, entity_type_series: Dict[str, pd.DataFrame]) -> Any:
+        pass
+
+    def build_dash_app(self) -> Dash:
+        self._build_layout()
+        self._build_callbacks()
+        return self._app
+
+    def _build_layout(self):
+        self._app.layout = dbc.Container(
+            [
+                html.H1(self._title),
+                html.Hr(),
+                dbc.Row(
+                    [
+                        dbc.Col(self._build_card(), md=4),
+                        dbc.Col(
+                            dcc.Graph(id=GRAPH_ID,
+                                      figure=self.make_figure({})),
+                            md=8
+                        )
+                    ],
+                    align="center",
+                )
+            ],
+            fluid=True
+        )
+
+    def _build_card(self) -> Component:
+        return dbc.Card(
+            [
+                html.Div([
+                    html.H3(self._base_path.tenant())
+                ]),
+                html.Div([
+                    html.H5(f"service path: {self._base_path.service_path()}")
+                ]),
+                html.Hr(),
+                dcc.Markdown(self.explanation()),
+                html.Hr(),
+                dbc.Row([
+                    dbc.Col(
+                        dbc.Label('Entities from'),
+                        md=4
+                    ),
+                    dbc.Col(
+                        datetime_local_input(ENTRIES_FROM_INPUT_ID),
+                        md=8
+                    )
+                ]),
+                html.P(),
+                dbc.Row([
+                    dbc.Col(
+                        dbc.Label('Entities to'),
+                        md=4
+                    ),
+                    dbc.Col(
+                        datetime_local_input(ENTRIES_TO_INPUT_ID),
+                        md=8
+                    )
+                ]),
+                html.P(),
+                dbc.Row([
+                    dbc.Col(
+                        dbc.Button('Load Entities', id=LOAD_BUTTON_ID,
+                                    n_clicks=0)
+                    )
+                ])
+            ],
+            body=True
+        )
+
+    def _build_callbacks(self):
+        self._app.callback(
+            Output(GRAPH_ID, 'figure'),
+            Input(LOAD_BUTTON_ID, 'n_clicks'),
+            Input(ENTRIES_FROM_INPUT_ID, 'value'),
+            Input(ENTRIES_TO_INPUT_ID, 'value')
+        )(self._update_graph)
+
+    def _update_graph(self, btn_clicks, entries_from, entries_to) -> Any:
+        frames = {}  # draw empty plot
+
+        if has_triggered(LOAD_BUTTON_ID):
+            from_time = from_datetime_local_input(entries_from)
+            to_time = from_datetime_local_input(entries_to)
+            if from_time and to_time:
+                frames = self._quantumleap.fetch_entity_type_series(
+                    entity_type=self._entity_type,
+                    from_timepoint=from_time, to_timepoint=to_time
+                )
+
+        return self.make_figure(frames)

--- a/dazzler/dash/entitymon.py
+++ b/dazzler/dash/entitymon.py
@@ -134,7 +134,7 @@ class EntityMonitorDashboard(ABC):
         if not entity_id:
             return self._empty_fig()
 
-        df = self._quantumleap.fetch_data_frame(
+        df = self._quantumleap.fetch_entity_series(
             entity_id=entity_id, entity_type=self._entity_type,
             entries_from_latest=entries_from_latest
         )

--- a/dazzler/dash/timeseries.py
+++ b/dazzler/dash/timeseries.py
@@ -29,7 +29,7 @@ class QuantumLeapSource:
             ctx=fiware_context_for(app)
         )
 
-    def fetch_data_frame(self,
+    def fetch_entity_series(self,
             entity_id: str, entity_type: str,
             entries_from_latest: Optional[int] = None,
             from_timepoint: Optional[datetime] = None,

--- a/dazzler/dash/timeseries.py
+++ b/dazzler/dash/timeseries.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from dash import Dash
 from fipy.ngsi.headers import FiwareContext
@@ -41,6 +41,22 @@ class QuantumLeapSource:
         )
         time_indexed_df = pd.DataFrame(r.dict()).set_index('index')
         return time_indexed_df
+
+    def fetch_entity_type_series(self,
+            entity_type: str,
+            entries_from_latest: Optional[int] = None,
+            from_timepoint: Optional[datetime] = None,
+            to_timepoint: Optional[datetime] = None) -> Dict[str, pd.DataFrame]:
+        rs = self._client.entity_type_series(
+            entity_type=entity_type,
+            entries_from_latest=entries_from_latest,
+            from_timepoint=from_timepoint, to_timepoint=to_timepoint
+        )
+        frames = {
+            entity_id : (pd.DataFrame(series.dict()))
+            for (entity_id, series) in rs.items()
+        }
+        return frames
 
     def fetch_entity_summaries(self, entity_type: Optional[str] = None) \
         -> List[BaseEntity]:

--- a/dazzler/ngsy.py
+++ b/dazzler/ngsy.py
@@ -17,7 +17,7 @@ class InspectionDemoEntity(BaseEntity):
     area: FloatAttr
 
 
-# RAW_MATERIAL_INSPECTION_TYPE = 'raw_material'
+RAW_MATERIAL_INSPECTION_TYPE = 'raw_material'
 
 # class RawMaterialInspectionEntity(BaseEntity):
 #     type = RAW_MATERIAL_INSPECTION_TYPE

--- a/dazzler/ngsy.py
+++ b/dazzler/ngsy.py
@@ -1,4 +1,4 @@
-from fipy.ngsi.entity import BaseEntity, BoolAttr, FloatAttr
+from fipy.ngsi.entity import BaseEntity, BoolAttr, FloatAttr, TextAttr
 
 
 ROUGHNESS_ESTIMATE_TYPE = 'RoughnessEstimate'
@@ -9,9 +9,28 @@ class RoughnessEstimateEntity(BaseEntity):
     roughness: FloatAttr
 
 
-RAW_MATERIAL_INSPECTION_TYPE = 'Raw_Material'
+INSPECTION_DEMO_TYPE = 'inspection_demo'
 
-class RawMaterialInspectionEntity(BaseEntity):
-    type = RAW_MATERIAL_INSPECTION_TYPE
-    Inspection_Result: BoolAttr
-    Area: FloatAttr
+class InspectionDemoEntity(BaseEntity):
+    type = INSPECTION_DEMO_TYPE
+    okay: BoolAttr
+    area: FloatAttr
+
+
+# RAW_MATERIAL_INSPECTION_TYPE = 'raw_material'
+
+# class RawMaterialInspectionEntity(BaseEntity):
+#     type = RAW_MATERIAL_INSPECTION_TYPE
+#     # Inspection_Result: BoolAttr
+#     # Area: FloatAttr
+#     okay: BoolAttr
+#     conformance_indicator: FloatAttr
+
+
+# TWEEZERS_INSPECTION_TYPE = 'tweezers_measurement'
+
+# class TweezersInspectionEntity(BaseEntity):
+#     type = TWEEZERS_INSPECTION_TYPE
+#     okay: BoolAttr
+#     conformance_indicator: FloatAttr
+#     spec: TextAttr

--- a/dazzler/ngsy.py
+++ b/dazzler/ngsy.py
@@ -27,7 +27,7 @@ RAW_MATERIAL_INSPECTION_TYPE = 'raw_material'
 #     conformance_indicator: FloatAttr
 
 
-# TWEEZERS_INSPECTION_TYPE = 'tweezers_measurement'
+TWEEZERS_INSPECTION_TYPE = 'tweezers_measurement'
 
 # class TweezersInspectionEntity(BaseEntity):
 #     type = TWEEZERS_INSPECTION_TYPE

--- a/poetry.lock
+++ b/poetry.lock
@@ -66,19 +66,19 @@ python-versions = "*"
 
 [[package]]
 name = "certifi"
-version = "2021.10.8"
+version = "2022.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.12"
+version = "2.1.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
-python-versions = ">=3.5.0"
+python-versions = ">=3.6.0"
 
 [package.extras]
 unicode_backport = ["unicodedata2"]
@@ -211,8 +211,8 @@ test = ["pytest (>=6.2.4,<7.0.0)", "pytest-cov (>=2.12.0,<4.0.0)", "mypy (==0.91
 
 [[package]]
 name = "fipy"
-version = "0.5.0"
-description = ""
+version = "0.6.1"
+description = "Python utils for a little sweeter FIWARE experience."
 category = "main"
 optional = false
 python-versions = "^3.8"
@@ -228,8 +228,8 @@ uri = "^2.0.1"
 [package.source]
 type = "git"
 url = "https://github.com/c0c0n3/kitt4sme.fipy.git"
-reference = "0.5.0"
-resolved_reference = "cb389d3a9bc5b3784da9e853c3e57a8503e13767"
+reference = "0.6.1"
+resolved_reference = "336b6cfc4536dffb5dd97a26d84e64a651555c1e"
 
 [[package]]
 name = "flask"
@@ -517,21 +517,21 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "requests"
-version = "2.27.1"
+version = "2.28.1"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.7, <4"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
-idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+charset-normalizer = ">=2,<3"
+idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "six"
@@ -604,11 +604,11 @@ http = ["requests"]
 
 [[package]]
 name = "urllib3"
-version = "1.26.9"
+version = "1.26.11"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
 brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
@@ -696,7 +696,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c628cddb2d19afed74ef99568d0e27eb1ba41851a532954bc14f4a272cbc6042"
+content-hash = "70a7789241527bbd905a9f414234d29a8413be0d0ab564f3b77610e07e155221"
 
 [metadata.files]
 anyio = [
@@ -782,14 +782,8 @@ brotli = [
     {file = "Brotli-1.0.9-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:76ffebb907bec09ff511bb3acc077695e2c32bc2142819491579a695f77ffd4d"},
     {file = "Brotli-1.0.9.zip", hash = "sha256:4d1b810aa0ed773f81dceda2cc7b403d01057458730e309856356d4ef4188438"},
 ]
-certifi = [
-    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
-    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
-]
-charset-normalizer = [
-    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
-    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
-]
+certifi = []
+charset-normalizer = []
 click = [
     {file = "click-8.1.2-py3-none-any.whl", hash = "sha256:24e1a4a9ec5bf6299411369b208c1df2188d9eb8d916302fe6bf03faed227f1e"},
     {file = "click-8.1.2.tar.gz", hash = "sha256:479707fe14d9ec9a0757618b7a100a0ae4c4e236fac5b7f80ca68028141a1a72"},
@@ -1137,10 +1131,7 @@ pyyaml = [
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
-requests = [
-    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
-    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
-]
+requests = []
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -1169,10 +1160,7 @@ uri = [
     {file = "uri-2.0.1-py2.py3-none-any.whl", hash = "sha256:df7df5653c8d38cf8a394db0d86728fcbfc6b4ecc62522a7972e078c1cace963"},
     {file = "uri-2.0.1.tar.gz", hash = "sha256:b56fa1ca7fdbb43d919d921c360a145358529d5430dec90d46a7b902179529b9"},
 ]
-urllib3 = [
-    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
-    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
-]
+urllib3 = []
 uvicorn = [
     {file = "uvicorn-0.17.6-py3-none-any.whl", hash = "sha256:19e2a0e96c9ac5581c01eb1a79a7d2f72bb479691acd2b8921fce48ed5b961a6"},
     {file = "uvicorn-0.17.6.tar.gz", hash = "sha256:5180f9d059611747d841a4a4c4ab675edf54c8489e97f96d0583ee90ac3bfc23"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dash-bootstrap-components = "^1.0.3"
 dash-bootstrap-templates = "^1.0.5"
 fastapi = "^0.75.0"
 Flask = "^2.1.1"
-fipy = {git = "https://github.com/c0c0n3/kitt4sme.fipy.git", tag = "0.5.0"}
+fipy = {git = "https://github.com/c0c0n3/kitt4sme.fipy.git", rev = "0.6.1"}
 pandas = "^1.4.1"
 pydantic = "^1.9.0"
 uvicorn = {extras = ["standard"], version = "^0.17.6"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dazzler"
-version = "0.2.0"
+version = "0.3.0"
 description = "Dazzling Dash-boards for KITT4SME services."
 authors = ["c0c0n3"]
 

--- a/tests/sim/dazzler-config.yaml
+++ b/tests/sim/dazzler-config.yaml
@@ -3,5 +3,5 @@ boards:
   demo:
   - builder: dazzler.dash.board.roughnator.dash_builder
     board_path: roughnator
-  - builder: dazzler.dash.board.viqe.dash_builder
-    board_path: viqe
+  - builder: dazzler.dash.board.inspection_demo.dash_builder
+    board_path: sleuth

--- a/tests/sim/runner.py
+++ b/tests/sim/runner.py
@@ -4,7 +4,7 @@ from fipy.docker import DockerCompose
 from fipy.ngsi.quantumleap import QuantumLeapClient
 
 from tests.util.fiware import quantumleap_client, \
-    raw_material_inspection_batches_stream, roughness_estimate_batches_stream
+    inspection_demo_batches_stream, roughness_estimate_batches_stream
 
 
 docker = DockerCompose(__file__)
@@ -18,7 +18,7 @@ def bootstrap():
 def send_entities(quantumleap: QuantumLeapClient):
     try:
         batch = next(roughness_estimate_batches_stream) + \
-                next(raw_material_inspection_batches_stream)
+                next(inspection_demo_batches_stream)
         quantumleap.insert_entities(batch)
     except Exception as e:
         print(e)

--- a/tests/unit/dash/board/test_viqe_report.py
+++ b/tests/unit/dash/board/test_viqe_report.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from typing import Dict, List, Tuple
+
+import pandas as pd
+
+from dazzler.dash.board.viqe import ReportFrame
+
+
+def mk_entity_series_row(time_index_iso: str,
+                         conformance_indicator: float,
+                         okay: bool) -> dict:
+    return {
+        'index': datetime.fromisoformat(time_index_iso),
+        'conformance_indicator': conformance_indicator,
+        'okay': okay
+    }
+
+
+EntitySeriesRow = Tuple[str, float, bool]
+
+
+def mk_entity_series_frame(rows: List[EntitySeriesRow]) -> pd.DataFrame:
+    rs = [mk_entity_series_row(*t) for t in rows]
+    return pd.DataFrame(rs)
+
+
+def mk_raw_material_entity_type_series() -> Dict[str, pd.DataFrame]:
+    return {
+        'steel-slab:1': mk_entity_series_frame([
+            ('2022-08-06 17:42:37.524000+00:00', 0.2, True),
+            ('2022-08-06 17:42:44.493000+00:00', 0.3, True)
+        ]),
+        'steel-slab:2': mk_entity_series_frame([
+            ('2022-08-06 17:42:37.528000+00:00', 1.0, False),
+            ('2022-08-06 17:42:44.496000+00:00', 0.9, False)
+        ]),
+        'steel-slab:3': mk_entity_series_frame([
+            ('2022-08-06 17:42:37.529000+00:00', 0.0, True),
+            ('2022-08-06 17:42:44.496000+00:00', 0.1, True)
+        ])
+    }
+
+
+def test_raw_material_report_from_entity_type_series():
+    ql_data = mk_raw_material_entity_type_series()
+    report_frame = ReportFrame(ql_data).build()
+
+    assert len(report_frame.index) == 3
+
+    id_values = report_frame['id'].tolist()
+    conformance_values = report_frame['conformance'].tolist()
+    scrap_values = report_frame['scrap'].tolist()
+
+    assert id_values == ['steel-slab:1', 'steel-slab:2', 'steel-slab:3']
+    assert conformance_values == [0.3, 0.9, 0.1]
+    assert scrap_values == [False, True, False]

--- a/tests/unit/dash/board/test_viqe_report.py
+++ b/tests/unit/dash/board/test_viqe_report.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 
@@ -8,15 +8,20 @@ from dazzler.dash.board.viqe import ReportFrame
 
 def mk_entity_series_row(time_index_iso: str,
                          conformance_indicator: float,
-                         okay: bool) -> dict:
-    return {
+                         okay: bool,
+                         spec: Optional[str] = None) -> dict:
+    row = {
         'index': datetime.fromisoformat(time_index_iso),
         'conformance_indicator': conformance_indicator,
         'okay': okay
     }
+    if spec:
+        row['spec'] = spec
+
+    return row
 
 
-EntitySeriesRow = Tuple[str, float, bool]
+EntitySeriesRow = Union[Tuple[str, float, bool], Tuple[str, float, bool, str]]
 
 
 def mk_entity_series_frame(rows: List[EntitySeriesRow]) -> pd.DataFrame:
@@ -54,3 +59,37 @@ def test_raw_material_report_from_entity_type_series():
     assert id_values == ['steel-slab:1', 'steel-slab:2', 'steel-slab:3']
     assert conformance_values == [0.3, 0.9, 0.1]
     assert scrap_values == [False, True, False]
+
+
+def mk_tweezers_entity_type_series() -> Dict[str, pd.DataFrame]:
+    return {
+        'tweezers:1': mk_entity_series_frame([
+            ('2022-08-06 17:42:37.524000+00:00', 0.2, True, 'spec:1'),
+            ('2022-08-06 17:42:44.493000+00:00', 0.3, True, 'spec:1')
+        ]),
+        'tweezers:2': mk_entity_series_frame([
+            ('2022-08-06 17:42:37.528000+00:00', 1.0, False, 'spec:1'),
+            ('2022-08-06 17:42:44.496000+00:00', 0.9, False, 'spec:1')
+        ]),
+        'tweezers:3': mk_entity_series_frame([
+            ('2022-08-06 17:42:37.529000+00:00', 0.0, True, 'spec:2'),
+            ('2022-08-06 17:42:44.496000+00:00', 0.1, True, 'spec:2')
+        ])
+    }
+
+
+def test_tweezers_report_from_entity_type_series():
+    ql_data = mk_tweezers_entity_type_series()
+    report_frame = ReportFrame(ql_data).build()
+
+    assert len(report_frame.index) == 3
+
+    id_values = report_frame['id'].tolist()
+    conformance_values = report_frame['conformance'].tolist()
+    scrap_values = report_frame['scrap'].tolist()
+    specs = report_frame['spec'].tolist()
+
+    assert id_values == ['tweezers:1', 'tweezers:2', 'tweezers:3']
+    assert conformance_values == [0.3, 0.9, 0.1]
+    assert scrap_values == [False, True, False]
+    assert specs == ['spec:1', 'spec:1', 'spec:2']

--- a/tests/util/fiware.py
+++ b/tests/util/fiware.py
@@ -7,7 +7,7 @@ from fipy.sim.generator import BoolAttr, float_attr_close_to, \
     EntityFactory, entity_batch
 from fipy.wait import wait_for_quantumleap
 
-from dazzler.ngsy import RawMaterialInspectionEntity, RoughnessEstimateEntity
+from dazzler.ngsy import InspectionDemoEntity, RoughnessEstimateEntity
 
 
 TENANT = 'demo'
@@ -47,23 +47,22 @@ def mk_roughness_estimate_batches_stream() \
 roughness_estimate_batches_stream = mk_roughness_estimate_batches_stream()
 
 
-def mk_raw_material_inspection() -> RawMaterialInspectionEntity:
+def mk_inspection_demo() -> InspectionDemoEntity:
     area = float_attr_close_to(0)
-    result = BoolAttr.new(area.value >= 0.4)
-    return RawMaterialInspectionEntity(
+    okay = BoolAttr.new(area.value >= 0.4)
+    return InspectionDemoEntity(
         id = '',
-        Inspection_Result=result,
-        Area=area
+        okay=okay,
+        area=area
     )
 
 
-def mk_raw_material_inspection_batches_stream() \
-    -> Generator[List[RawMaterialInspectionEntity], None, None]:
+def mk_inspection_demo_batches_stream() \
+    -> Generator[List[InspectionDemoEntity], None, None]:
     factory = EntityFactory.with_numeric_suffixes(
-        how_many=2, generator=mk_raw_material_inspection
+        how_many=2, generator=mk_inspection_demo
     )
     return entity_batch(factory)
 
 
-raw_material_inspection_batches_stream = \
-    mk_raw_material_inspection_batches_stream()
+inspection_demo_batches_stream = mk_inspection_demo_batches_stream()


### PR DESCRIPTION
This PR "cloudifies" the VIQE client inspection plots. In the process we also fixed a couple of Dazzler issues and did some refactoring.

There's two dashboards, one to plot raw materials inspection reports, the other to plot tweezers inspection reports. These reports are NGSI entities Dazzler sources from Quantum Leap.

The raw materials dashboard visualises raw material inspections VIQE did in a selected time interval. Each inspection refers to a specific raw material item which is identified by an ID label. There's a bar on the graph for each ID. The bar indicates the degree to which the inspected item conforms to the spec. Zero means no significant deviations from the spec, one means the item is probably to be scrapped. The spec determines a conformance threshold `t` in `(0, 1)` so items with a value less or equal to `t` conform to the spec whereas values greater than `t` do not. Accordingly, a grey bar means "below or equal to the threshold", whereas orange means "above the threshold".

The tweezers dashboard visualises tweezers inspections VIQE did in a selected time interval. Each inspection refers to a specific tweezers which is identified by an ID label. There's a bar on the graph for each ID. The bar indicates the degree to which the inspected item conforms to the spec. Zero means no significant deviations from the spec, one means the item is probably to be scrapped. The spec determines a conformance threshold `t` in `(0, 1)` so items with a value less or equal to `t` conform to the spec whereas values greater than `t` do not. Accordingly, a grey bar means "below or equal to the threshold", whereas orange means "above the  threshold". To see which spec VIQE checked a pair of tweezers against, you hover over the corresponding bar in the graph with the mouse.